### PR TITLE
fix: Bug 0078 - past date(year) limit validation changed into 1800s

### DIFF
--- a/packages/client/src/components/DateRangePicker.tsx
+++ b/packages/client/src/components/DateRangePicker.tsx
@@ -42,7 +42,7 @@ import endOfMonth from 'date-fns/endOfMonth'
 
 const { useState, useEffect, useMemo } = React
 
-const LIMIT_YEAR_PAST_RECORDS = 1900
+const LIMIT_YEAR_PAST_RECORDS = 1800
 
 function getMonthsShort(locale = 'en') {
   const months = []

--- a/packages/client/src/utils/validate.ts
+++ b/packages/client/src/utils/validate.ts
@@ -307,30 +307,30 @@ export const isValidBirthDate: Validation = (
   return !cast
     ? { message: messages.required }
     : cast &&
-        isDateNotInFuture(cast) &&
-        isAValidDateFormat(cast) &&
-        isDateNotAfterBirthEvent(cast, drafts as IFormData)
-      ? isDateNotAfterDeath(cast, drafts as IFormData)
-        ? undefined
-        : {
-            message: messages.isDateNotAfterDeath
-          }
+      isDateNotInFuture(cast) &&
+      isAValidDateFormat(cast) &&
+      isDateNotAfterBirthEvent(cast, drafts as IFormData)
+    ? isDateNotAfterDeath(cast, drafts as IFormData)
+      ? undefined
       : {
-          message: messages.isValidBirthDate
+          message: messages.isDateNotAfterDeath
         }
+    : {
+        message: messages.isValidBirthDate
+      }
 }
 
 export const isValidChildBirthDate: Validation = (value: IFormFieldValue) => {
   const childBirthDate = value as string
-  const pastDateLimit = new Date(1900, 0, 1)
+  const pastDateLimit = new Date(1800, 0, 1)
   return !childBirthDate
     ? { message: messages.required }
     : childBirthDate &&
-        isAValidDateFormat(childBirthDate) &&
-        isDateNotInFuture(childBirthDate) &&
-        isDateNotPastLimit(childBirthDate, pastDateLimit)
-      ? undefined
-      : { message: messages.isValidBirthDate }
+      isAValidDateFormat(childBirthDate) &&
+      isDateNotInFuture(childBirthDate) &&
+      isDateNotPastLimit(childBirthDate, pastDateLimit)
+    ? undefined
+    : { message: messages.isValidBirthDate }
 }
 
 export const isValidParentsBirthDate =
@@ -765,8 +765,8 @@ export const greaterThanZero: Validation = (value: IFormFieldValue) => {
   return !value && value !== 0
     ? { message: messages.required }
     : value && Number(value) > 0
-      ? undefined
-      : { message: messages.greaterThanZero }
+    ? undefined
+    : { message: messages.greaterThanZero }
 }
 
 export const notGreaterThan =

--- a/packages/components/src/DateField/DateField.tsx
+++ b/packages/components/src/DateField/DateField.tsx
@@ -101,7 +101,7 @@ export const DateField = ({
           if (
             val.length > 4 ||
             Number(val) > MAX_YEAR_NUMBER ||
-            (val.length === 2 && Number(val) < 19)
+            (val.length === 2 && Number(val) < 18)
           ) {
             return
           }
@@ -174,7 +174,7 @@ export const DateField = ({
           type="number"
           placeholder={ignorePlaceHolder ? '' : 'yyyy'}
           maxLength={4}
-          min={1900}
+          min={1800}
           value={yyyy}
           onChange={change}
           onWheel={(event: React.WheelEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Clickup Bug ID - TONGA-CRVS-0078-Displayed validation error for birth records from the 1800s

Validation for birth year `Should be 1900s or above` is changed into `Should be 1800s or above`. Code changes includes,

- Validator function `isValidChildBirthDate`.
- `LIMIT_YEAR_PAST_RECORDS` in [DateRangePicker.tsx](https://github.com/Digital-Transformation-Tonga/opencrvs-tonga-core/blob/bb2c9dbbd270973f930fe479c922a98cc7369339/packages/client/src/components/DateRangePicker.tsx#L45C7-L45C30).
- Conditional changes in [here](https://github.com/Digital-Transformation-Tonga/opencrvs-tonga-core/blob/bb2c9dbbd270973f930fe479c922a98cc7369339/packages/components/src/DateField/DateField.tsx#L104) & [here](https://github.com/Digital-Transformation-Tonga/opencrvs-tonga-core/blob/bb2c9dbbd270973f930fe479c922a98cc7369339/packages/components/src/DateField/DateField.tsx#L177).