### PR TITLE
Fix: registration number search issue

### DIFF
--- a/packages/search/src/features/search/utils.ts
+++ b/packages/search/src/features/search/utils.ts
@@ -694,8 +694,8 @@ export async function advancedQueryBuilder(
 
   if (params.registrationNumber) {
     must.push({
-      match: {
-        registrationNumber: params.registrationNumber
+      term: {
+        'registrationNumber.keyword': params.registrationNumber
       }
     })
   }


### PR DESCRIPTION
## Description
Registration number will only be returned when the entered one is fully equal when searching.