### PR TITLE
Displaying invalid values for some fields when scanning the QR codes

### DIFF
--- a/packages/client/src/utils/gateway.ts
+++ b/packages/client/src/utils/gateway.ts
@@ -7626,6 +7626,7 @@ export type FetchRecordDetailsForVerificationQuery = {
             line?: Array<string | null> | null
           } | null
         } | null
+        questionnaire?: Maybe<Maybe<QuestionnaireQuestion>[]> | undefined
         registration?: {
           __typename?: 'Registration'
           trackingId?: string | null
@@ -7688,6 +7689,7 @@ export type FetchRecordDetailsForVerificationQuery = {
             country?: string | null
           } | null
         } | null
+        questionnaire?: Maybe<Maybe<QuestionnaireQuestion>[]> | undefined
         registration?: {
           __typename?: 'Registration'
           trackingId?: string | null

--- a/packages/client/src/views/VerifyCertificate/VerifyCertificatePage.tsx
+++ b/packages/client/src/views/VerifyCertificate/VerifyCertificatePage.tsx
@@ -253,6 +253,41 @@ export function VerifyCertificatePage() {
       ?.date
   }
 
+  const getPlaceofBirthOrDeath = (data: RegistrationToBeVerified) => {
+    const questionnaireData: any = data.questionnaire
+    if (isBirthRegistration(data)) {
+      const placeOfBirthObject = questionnaireData?.find(
+        (item: { fieldId: string; value: string }) =>
+          item.fieldId === 'birth.child.child-view-group.childPlaceOfBirth'
+      )
+      return placeOfBirthObject ? placeOfBirthObject.value : '-'
+    }
+    if (isDeathRegistration(data)) {
+      const placeOfDeathObject = questionnaireData?.find(
+        (item: { fieldId: string; value: string }) =>
+          item.fieldId === 'death.deathEvent.deathEvent-view-group.deathPlace'
+      )
+      return placeOfDeathObject ? placeOfDeathObject.value : '-'
+    }
+    return '-'
+  }
+
+  const getRegistrationCenter = (data: RegistrationToBeVerified) => {
+    let registrationCenter = ''
+    let locationId = ''
+
+    const officeHierarchy = getRegistarData(data).officeHierarchy
+
+    for (const location of officeHierarchy ?? []) {
+      if (registrationCenter && locationId) {
+        break
+      }
+      locationId = location.id
+      registrationCenter = localizeLocation(location)
+    }
+    return { registrationCenter, locationId }
+  }
+
   // This function currently supports upto two location levels
   const getLocation = (data: RegistrationToBeVerified) => {
     const location = data.eventLocation
@@ -435,7 +470,7 @@ export function VerifyCertificatePage() {
                       }
                       value={
                         <Text variant={'reg16'} element={'span'}>
-                          {getLocation(data)}
+                          {getPlaceofBirthOrDeath(data)}
                         </Text>
                       }
                     />
@@ -453,17 +488,13 @@ export function VerifyCertificatePage() {
                           alignItems="flex-start"
                           gap={0}
                         >
-                          {getRegistarData(data).officeHierarchy?.map(
-                            (location) => (
-                              <Text
-                                key={location.id}
-                                variant="reg16"
-                                element="span"
-                              >
-                                {localizeLocation(location)}
-                              </Text>
-                            )
-                          )}
+                          <Text
+                            key={getRegistrationCenter(data).locationId}
+                            variant="reg16"
+                            element="span"
+                          >
+                            {getRegistrationCenter(data).registrationCenter}
+                          </Text>
                         </Stack>
                       }
                     />

--- a/packages/client/src/views/VerifyCertificate/useVerificationRecordDetails.ts
+++ b/packages/client/src/views/VerifyCertificate/useVerificationRecordDetails.ts
@@ -39,6 +39,10 @@ const FETCH_RECORD_DETAILS_FOR_VERIFICATION = gql`
             line
           }
         }
+        questionnaire {
+          fieldId
+          value
+        }
         registration {
           trackingId
           registrationNumber
@@ -88,6 +92,10 @@ const FETCH_RECORD_DETAILS_FOR_VERIFICATION = gql`
             city
             country
           }
+        }
+        questionnaire {
+          fieldId
+          value
         }
         registration {
           trackingId


### PR DESCRIPTION
Bug ID - TONGA-CRVS-0085

Description - Made amendments to display the correct values for place of birth/death & registration center fields in certificate verification page (when scanning the QR codes in certificate)

Changes includes,

- Added relevent types for [`FetchRecordDetailsForVerificationQuery`](https://github.com/Digital-Transformation-Tonga/opencrvs-tonga-core/blob/844d1650743ac94a38279803bf00ffcd57917c14/packages/client/src/utils/gateway.ts#L7597) in `gateway.ts`
- Created [functions ](https://github.com/Digital-Transformation-Tonga/opencrvs-tonga-core/blob/844d1650743ac94a38279803bf00ffcd57917c14/packages/client/src/views/VerifyCertificate/VerifyCertificatePage.tsx#L256-L289) to retrieve correct values for place of birth/ death & registration center fields in `VerifyCertificatePage.tsx`
- Made UI changes to display [place of birth/death](https://github.com/Digital-Transformation-Tonga/opencrvs-tonga-core/blob/844d1650743ac94a38279803bf00ffcd57917c14/packages/client/src/views/VerifyCertificate/VerifyCertificatePage.tsx#L473) & [registration center](https://github.com/Digital-Transformation-Tonga/opencrvs-tonga-core/blob/844d1650743ac94a38279803bf00ffcd57917c14/packages/client/src/views/VerifyCertificate/VerifyCertificatePage.tsx#L491-L497) (above retrieved values) in corresponding fields
- Made changes to the [FETCH_RECORD_DETAILS_FOR_VERIFICATION](https://github.com/Digital-Transformation-Tonga/opencrvs-tonga-core/blob/844d1650743ac94a38279803bf00ffcd57917c14/packages/client/src/views/VerifyCertificate/useVerificationRecordDetails.ts#L16C7-L16C44) graphql query in `useVerificationRecordDetails.ts` to retrieve questionnaire values