### PR TITLE
TONGA-CRVS-0041-Date of Birth Not Displayed in Verify Their Identity UI

### DIFF
--- a/packages/client/src/views/PrintCertificate/VerifyCollector.tsx
+++ b/packages/client/src/views/PrintCertificate/VerifyCollector.tsx
@@ -178,10 +178,23 @@ class VerifyCollectorComponent extends React.Component<IFullProps> {
     const isExactDobUnknownForIdVerifier =
       !!declaration?.data[collector]?.exactDateOfBirthUnknown
 
-    const birthDate =
+    let birthDate =
       fields.birthDateField && !isExactDobUnknownForIdVerifier
         ? (info[fields.birthDateField] as string)
         : ''
+
+    if (declaration?.event === 'death' && collector === 'informant') {
+      const deathEventInformantType = (
+        declaration!.data['informant']['informantType'] as string
+      ).toLowerCase()
+
+      if (deathEventInformantType === 'mother') {
+        birthDate = declaration!.data['mother']['motherBirthDate'] as string
+      }
+      if (deathEventInformantType === 'father') {
+        birthDate = declaration!.data['father']['fatherBirthDate'] as string
+      }
+    }
 
     const age = isExactDobUnknownForIdVerifier
       ? (info[fields.ageOfPerson as string] as string)


### PR DESCRIPTION
It's only mentioned about the death event scenario in the bug description. And the fixes are also done corresponds to the death event's 'Verify their identity' page only.