### PR TITLE
TONGA-CRVS-0127 Some death declarations are automatically reject when registering

### DIFF
--- a/packages/workflow/src/records/handler/create.ts
+++ b/packages/workflow/src/records/handler/create.ts
@@ -34,7 +34,8 @@ import {
   Encounter,
   Location,
   findEncounterFromRecord,
-  Saved
+  Saved,
+  findCompositionSection
 } from '@opencrvs/commons/types'
 import {
   getToken,
@@ -186,6 +187,52 @@ async function createRecord(
     token
   )
   const composition = getComposition(inputBundle)
+
+  if (
+    composition?.type?.coding?.[0]?.code &&
+    composition.type.coding[0].code === 'death-declaration'
+  ) {
+    const informantDetailsSection = findCompositionSection(
+      'informant-details',
+      composition
+    )
+    const informantReferenceID = informantDetailsSection?.entry[0]?.reference
+
+    const relatedPersonResource: any = inputBundle.entry.find((item) => {
+      return item.fullUrl === informantReferenceID
+    })
+
+    const informantType =
+      relatedPersonResource?.resource?.relationship?.coding?.[0]?.code
+
+    if (informantType && informantType === 'MOTHER') {
+      const informantDetailsSection = findCompositionSection(
+        'mother-details',
+        composition
+      )
+      const motherReferenceID = informantDetailsSection?.entry?.[0]?.reference
+
+      if (motherReferenceID) {
+        relatedPersonResource.resource.patient = {
+          reference: motherReferenceID
+        }
+      }
+    }
+    if (informantType && informantType === 'FATHER') {
+      const informantDetailsSection = findCompositionSection(
+        'father-details',
+        composition
+      )
+      const fatherReferenceID = informantDetailsSection?.entry?.[0]?.reference
+
+      if (fatherReferenceID) {
+        relatedPersonResource.resource.patient = {
+          reference: fatherReferenceID
+        }
+      }
+    }
+  }
+
   const inProgress = isInProgressDeclaration(inputBundle)
 
   composition.identifier = {


### PR DESCRIPTION
In `RelatedPerson` resource, reference to the `Patient` resource is not getting created if the selected informant is `MOTHER` or `FATHER`. 

![image](https://github.com/user-attachments/assets/2b86679c-c874-4d7b-aec1-4d4117ea152a)

In the bundle, modification are done after the bundle creation and not during the creation.

(Possibly a bug in the OpenCRVS implementation. Might need to raise for the ocrvs for a clean fix)